### PR TITLE
Added Dapper support with generic query builder for fetch and insert requests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ src/DeviceManager.Api/Properties/PublishProfiles/registry.hub.docker.com_boriszn
 src/DeviceManager.Api/Properties/PublishProfiles/registry.hub.docker.com_boriszn.pubxml.user
 /src/DeviceManager.IdentityServer/IdentityServer.db
 /src/DeviceManager.Api/Dockerfile-VsDebug
+/src/DeviceManager.IdentityServer/identityserver4_log.txt

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ There can be multiple data seeding classes. To create a new data seeding class:
 1. Create a new data seeding class in the same folder inheriting from [IDataSeeder](src/DeviceManager.Api/Data/DataSeed/IDataSeeder.cs) interface.
 2. Register new class in the [IocContainerConfiguration](src/DeviceManager.Api/Configuration/IocContainerConfiguration.cs) class by replacing `DataSeeder` with new class name.
 
+## Dapper support
+
+Dapper is incorporated into the application. [DapperUnitOfWork](src/DeviceManager.Api/Data/Management/Dapper/DapperUnitOfWork.cs) handles all the begin and commit transaction. The instance of Dapper Unit of work can be obtained by requesting instance of [IDapperUnitOfWork](src/DeviceManager.Api/Data/Management/Dapper/IDapperUnitOfWork.cs).
+
+[DeviceService](src/DeviceManager.Api/Services/DeviceService.cs) is using [DapperUnitOfWork](src/DeviceManager.Api/Data/Management/Dapper/DapperUnitOfWork.cs) to fetch and create records in the database through [DapperRepository](src/DeviceManager.Api/Data/Management/Dapper/DapperRepository.cs). [DapperRepository](src/DeviceManager.Api/Data/Management/Dapper/DapperRepository.cs) is a generic repository with built in methods for fetching and adding records into the database based on [DapperInsert](src/DeviceManager.Api/Attributes/Dapper/DapperInsertAttribute.cs) and [DapperUpdate](src/DeviceManager.Api/Attributes/Dapper/DapperUpdateAttribute.cs) attributes defined on the Model. In the future update and delete will be implemented. 
+
+The [DapperRepository](src/DeviceManager.Api/Data/Management/Dapper/DapperRepository.cs) builds generic `insert` and `fetch` using [QueryBuilderHelper](src/DeviceManager.Api/Helpers/Dapper/QueryBuilderHelper.cs) class based on the attributes defined on the model. For example [Device](src/DeviceManager.Api/Data/Model/Device.cs) model defines `DapperInsert` on few properties. Only these property names will be considered while building `insert query`.
+
+The `Dapper` region in the [DeviceController](src/DeviceManager.Api/Controllers/DevicesController.cs) uses Dapper to fetch and create records in the database.
+
 ## Docker support
 
 App images available in Docker Hub Registry: https://hub.docker.com/r/boriszn/devicemanagerapi/ (**LINUX and Windows images are available**)

--- a/src/DeviceManager.Api/Attributes/Dapper/DapperInsertAttribute.cs
+++ b/src/DeviceManager.Api/Attributes/Dapper/DapperInsertAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace DeviceManager.Api.Attributes.Dapper
+{
+    /// <summary>
+    /// This attribute is used to indicate Dapper to select property in the Insert query
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class DapperInsertAttribute : Attribute
+    {
+    }
+}

--- a/src/DeviceManager.Api/Attributes/Dapper/DapperUpdateAttribute.cs
+++ b/src/DeviceManager.Api/Attributes/Dapper/DapperUpdateAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace DeviceManager.Api.Attributes.Dapper
+{
+    /// <summary>
+    /// This attribute is used to indicate Dapper to select property in the Update query
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class DapperUpdateAttribute : Attribute
+    {
+    }
+}

--- a/src/DeviceManager.Api/Configuration/IocContainerConfiguration.cs
+++ b/src/DeviceManager.Api/Configuration/IocContainerConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using DeviceManager.Api.Data.DataSeed;
 using DeviceManager.Api.Data.Management;
+using DeviceManager.Api.Data.Management.Dapper;
 using DeviceManager.Api.Services;
 using DeviceManager.Api.Validation;
 using Microsoft.AspNetCore.Http;
@@ -23,6 +24,7 @@ namespace DeviceManager.Api.Configuration
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
+            services.AddScoped(typeof(IDapperRepository<>), typeof(DapperRepository<>));
 
             services.AddScoped<IDeviceViewModelValidationRules, DeviceViewModelValidationRules>();
             
@@ -33,7 +35,10 @@ namespace DeviceManager.Api.Configuration
             services.AddTransient<IDataBaseManager, DataBaseManager>();
             services.AddTransient<IContextFactory, ContextFactory>();
 
+            services.AddTransient<IConnectionFactory, ConnectionFactory>();
+            
             services.AddTransient<IUnitOfWork, UnitOfWork>();
+            services.AddTransient<IDapperUnitOfWork, DapperUnitOfWork>();
 
             services.AddTransient<IDataSeeder, DataSeeder>();
         }

--- a/src/DeviceManager.Api/Controllers/DevicesController.cs
+++ b/src/DeviceManager.Api/Controllers/DevicesController.cs
@@ -30,6 +30,8 @@ namespace DeviceManager.Api.Controllers
             this.deviceService = deviceService;
         }
 
+        #region Entity Framework Core
+
         /// <summary>
         /// Gets the specified page.
         /// </summary>
@@ -112,5 +114,54 @@ namespace DeviceManager.Api.Controllers
 
             return new OkResult();
         }
+
+        #endregion
+
+        #region Dapper
+
+        /// <summary>
+        /// Gets all records using dapper.
+        /// </summary>
+        /// <param name="page">The page.</param>
+        /// <param name="pageSize">Size of the page.</param>
+        /// <returns></returns>
+        [HttpGet("dapper")]
+        [SwaggerOperation("GetAllDevicesUsingDapper")]
+        [ValidateActionParameters]
+        public async Task<IActionResult> GetAllUsingDapper([FromQuery, Required]int page, [FromQuery, Required]int pageSize)
+        {
+            return new ObjectResult(await deviceService.GetDevicesUsingDapper(page, pageSize));
+        }
+
+        /// <summary>
+        /// Gets the specified device identifier in async await pattern using dapper.
+        /// </summary>
+        /// <param name="deviceId">The device identifier.</param>
+        /// <returns></returns>
+        [HttpGet("dapper/async/{deviceId}")]
+        [SwaggerOperation(nameof(GetDeviceByIdAsync))]
+        [ValidateActionParameters]
+        public async Task<IActionResult> GetDeviceByIdUsingDapperAsync([FromRoute][Required]string deviceId)
+        {
+            return new ObjectResult(await deviceService.GetDeviceByIdUsingDapperAsync(Guid.Parse(deviceId)));
+        }
+
+        /// <summary>
+        /// Posts the specified device view model and executeds query using dapper.
+        /// </summary>
+        /// <param name="deviceViewModel">The device view model.</param>
+        /// <returns></returns>
+        [HttpPost("dapper")]
+        [SwaggerOperation("CreateDeviceUsingDapper")]
+        [SwaggerResponse(204, null, "Device was saved successfuly")]
+        [SwaggerResponse(400, null, "Error in saving the Device")]
+        public async Task<IActionResult> PostUsingDapepr([FromBody]DeviceViewModel deviceViewModel)
+        {
+            await deviceService.CreateDeviceUsingDapperAsync(deviceViewModel);
+
+            return new OkResult();
+        }
+
+        #endregion
     }
 }

--- a/src/DeviceManager.Api/Data/Management/Dapper/ConnectionFactory.cs
+++ b/src/DeviceManager.Api/Data/Management/Dapper/ConnectionFactory.cs
@@ -1,0 +1,32 @@
+﻿using DeviceManager.Api.Configuration.Settings;
+using Microsoft.Extensions.Options;
+using System.Data;
+using System.Data.SqlClient;
+
+namespace DeviceManager.Api.Data.Management.Dapper
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class ConnectionFactory : IConnectionFactory
+    {
+        private readonly string connectionString;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionFactory"/> class.
+        /// </summary>
+        /// <param name="setting">The setting.</param>
+        public ConnectionFactory(IOptions<ConnectionSettings> setting)
+        {
+            this.connectionString = setting.Value.DefaultConnection;
+        }
+
+        /// <summary>
+        /// Gets the connection.
+        /// </summary>
+        /// <value>
+        /// The connection.
+        /// </value>
+        public IDbConnection Connection => new SqlConnection(connectionString);
+    }
+}

--- a/src/DeviceManager.Api/Data/Management/Dapper/DapperRepository.cs
+++ b/src/DeviceManager.Api/Data/Management/Dapper/DapperRepository.cs
@@ -1,0 +1,82 @@
+﻿using Dapper;
+using DeviceManager.Api.Attributes.Dapper;
+using DeviceManager.Api.Helpers.Dapper;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Data;
+using System.Dynamic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DeviceManager.Api.Data.Management.Dapper
+{
+    /// <summary>
+    /// Implementation of Generic Dapper repository
+    /// </summary>
+    /// <typeparam name="T">Entity type</typeparam>
+    public class DapperRepository<T> : DapperRepositoryBase, IDapperRepository<T>
+    {
+        /// <summary>
+        /// Initializes instance of transaction
+        /// </summary>
+        /// <param name="transaction"></param>
+        public DapperRepository(IDbTransaction transaction)
+            : base(transaction)
+        {
+
+        }
+
+        /// <inherit/>
+        public async Task<Guid> AddAsync(T entity)
+        {
+
+            if (entity == null)
+                throw new ArgumentNullException(nameof(T));
+
+            var paramObject = new ExpandoObject();
+            foreach(var property in QueryBuilderHelper.GetPropertiesWithAttribute<T>(typeof(DapperInsertAttribute)))
+            {
+                paramObject.TryAdd(property.Name, property.GetValue(entity));
+            }
+            
+            return await Connection.ExecuteScalarAsync<Guid>(QueryBuilderHelper.GetInsertQuery<T>(), paramObject, Transaction);
+
+        }
+         
+        /// <inherit/>
+        public async Task<IList<T>> AllAsync(int page, int pageCount)
+        {
+            var records =  await Connection.QueryAsync<T>(QueryBuilderHelper.GetSelectQuery<T>(), transaction: Transaction);
+            return records.ToList();
+        }
+
+        /// <inherit/>
+        public async Task<T> FindAsync(Guid id)
+        {
+            var query = QueryBuilderHelper.GetFindQuery<T>();
+            var paramObject = new ExpandoObject();
+            paramObject.TryAdd(QueryBuilderHelper.GetPropertiesWithAttribute<T>(typeof(KeyAttribute)).FirstOrDefault().Name, id);
+            var record = await Connection.QueryAsync<T>(query, param: paramObject, transaction: Transaction);
+            return record.FirstOrDefault();
+        }
+
+        /// <inherit/>
+        public void RemoveAsync(T entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inherit/>
+        public void RemoveAsync(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inherit/>
+        public void UpdateAsync(T entity)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/DeviceManager.Api/Data/Management/Dapper/DapperRepositoryBase.cs
+++ b/src/DeviceManager.Api/Data/Management/Dapper/DapperRepositoryBase.cs
@@ -1,0 +1,35 @@
+﻿using System.Data;
+
+namespace DeviceManager.Api.Data.Management.Dapper
+{
+    /// <summary>
+    /// Base dapper repository
+    /// </summary>
+    public abstract class DapperRepositoryBase
+    {
+        /// <summary>
+        /// Gets the transaction.
+        /// </summary>
+        /// <value>
+        /// The transaction.
+        /// </value>
+        protected IDbTransaction Transaction { get; }
+
+        /// <summary>
+        /// Gets the connection.
+        /// </summary>
+        /// <value>
+        /// The connection.
+        /// </value>
+        protected IDbConnection Connection => Transaction.Connection;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DapperRepositoryBase"/> class.
+        /// </summary>
+        /// <param name="transaction">The transaction.</param>
+        protected DapperRepositoryBase(IDbTransaction transaction)
+        {
+            Transaction = transaction;
+        }
+    }
+}

--- a/src/DeviceManager.Api/Data/Management/Dapper/DapperUnitOfWork.cs
+++ b/src/DeviceManager.Api/Data/Management/Dapper/DapperUnitOfWork.cs
@@ -5,9 +5,8 @@ using System.Data;
 namespace DeviceManager.Api.Data.Management.Dapper
 {
     /// <summary>
-    /// 
+    /// Dapper Unit of work for maintaining the transaction
     /// </summary>
-    /// <typeparam name="T"></typeparam>
     public class DapperUnitOfWork : IDapperUnitOfWork, IDisposable
     {
         private IDbConnection connection;

--- a/src/DeviceManager.Api/Data/Management/Dapper/DapperUnitOfWork.cs
+++ b/src/DeviceManager.Api/Data/Management/Dapper/DapperUnitOfWork.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace DeviceManager.Api.Data.Management.Dapper
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class DapperUnitOfWork : IDapperUnitOfWork, IDisposable
+    {
+        private IDbConnection connection;
+        private IDbTransaction transaction;
+        private bool disposed;
+
+        /// <summary>
+        /// The repositories
+        /// </summary>
+        private Dictionary<Type, object> repositories;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnitOfWork"/> class.
+        /// </summary>
+        /// <param name="connectionFactory">The connection factory.</param>
+        public DapperUnitOfWork(IConnectionFactory connectionFactory)
+        {
+            this.connection = connectionFactory.Connection;
+        }
+
+        /// <inheritdoc />
+        public void BeginTransaction()
+        {
+            connection.Open();
+            transaction = connection.BeginTransaction();
+        }
+
+        /// <inheritdoc />
+        public IDapperRepository<TEntity> GetRepository<TEntity>()
+            where TEntity : class
+        {
+            if (this.repositories == null)
+            {
+                this.repositories = new Dictionary<Type, object>();
+            }
+
+            var type = typeof(TEntity);
+            if (!this.repositories.ContainsKey(type))
+            {
+                this.repositories[type] = new DapperRepository<TEntity>(transaction);
+            }
+
+            return (IDapperRepository<TEntity>)this.repositories[type];
+        }
+
+        /// <inheritdoc />
+        public void Commit()
+        {
+            try
+            {
+                transaction.Commit();
+            }
+            catch
+            {
+                transaction.Rollback();
+                throw;
+            }
+            finally
+            {
+                transaction.Dispose();
+                transaction = connection.BeginTransaction();
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+                    if (transaction != null)
+                    {
+                        transaction.Dispose();
+                        transaction = null;
+                    }
+                    if (connection != null)
+                    {
+                        connection.Dispose();
+                        connection = null;
+                    }
+                }
+                disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        ~DapperUnitOfWork()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/src/DeviceManager.Api/Data/Management/Dapper/IConnectionFactory.cs
+++ b/src/DeviceManager.Api/Data/Management/Dapper/IConnectionFactory.cs
@@ -1,0 +1,18 @@
+﻿using System.Data;
+
+namespace DeviceManager.Api.Data.Management.Dapper
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IConnectionFactory
+    {
+        /// <summary>
+        /// Gets the connection.
+        /// </summary>
+        /// <value>
+        /// The connection.
+        /// </value>
+        IDbConnection Connection { get; }
+    }
+}

--- a/src/DeviceManager.Api/Data/Management/Dapper/IDapperRepository.cs
+++ b/src/DeviceManager.Api/Data/Management/Dapper/IDapperRepository.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DeviceManager.Api.Data.Management.Dapper
+{
+    /// <summary>
+    /// Generic Repository contract for Dapper
+    /// </summary>
+    /// <typeparam name="TEntity">Database Entity Type</typeparam>
+    public interface IDapperRepository<TEntity>
+    {
+        /// <summary>
+        /// All instances.
+        /// </summary>
+        /// <param name="page">The identifier.</param>
+        /// <param name="pageCount">The identifier.</param>
+        /// <returns>Records from the table based on the page number and page count</returns>
+        Task<IList<TEntity>> AllAsync(int page, int pageCount);
+
+        /// <summary>
+        /// Finds the specified identifier.
+        /// </summary>
+        /// <param name="id">The identifier.</param>
+        /// <returns></returns>
+        Task<TEntity> FindAsync(Guid id);
+
+        /// <summary>
+        /// Adds the specified entity.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        Task<Guid> AddAsync(TEntity entity);
+
+        /// <summary>
+        /// Updates the specified entity.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        void UpdateAsync(TEntity entity);
+
+        /// <summary>
+        /// Removes the specified entity.
+        /// </summary>
+        /// <param name="entity">The entity.</param>
+        void RemoveAsync(TEntity entity);
+
+        /// <summary>
+        /// Removes the specified identifier.
+        /// </summary>
+        /// <param name="id">The identifier.</param>
+        void RemoveAsync(Guid id);
+    }
+}

--- a/src/DeviceManager.Api/Data/Management/Dapper/IDapperUnitOfWork.cs
+++ b/src/DeviceManager.Api/Data/Management/Dapper/IDapperUnitOfWork.cs
@@ -1,0 +1,32 @@
+﻿namespace DeviceManager.Api.Data.Management.Dapper
+{
+    /// <summary>
+    /// Represents repository/object creation and transaction management
+    /// </summary>
+    public interface IDapperUnitOfWork
+    {
+        /// <summary>
+        /// Gets the device repository.
+        /// </summary>
+        /// <value>
+        /// The device repository.
+        /// </value>
+        IDapperRepository<TEntity> GetRepository<TEntity>()
+            where TEntity : class;
+
+        /// <summary>
+        /// Begins the transaction.
+        /// </summary>
+        void BeginTransaction();
+
+        /// <summary>
+        /// Commits this instance.
+        /// </summary>
+        void Commit();
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        void Dispose();
+    }
+}

--- a/src/DeviceManager.Api/Data/Model/Device.cs
+++ b/src/DeviceManager.Api/Data/Model/Device.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DeviceManager.Api.Attributes.Dapper;
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace DeviceManager.Api.Data.Model
@@ -15,6 +16,7 @@ namespace DeviceManager.Api.Data.Model
         /// The device identifier.
         /// </value>
         [Key()]
+        [DapperInsert]
         public Guid DeviceId { get; set; }
 
         /// <summary>
@@ -23,16 +25,19 @@ namespace DeviceManager.Api.Data.Model
         /// <value>
         /// The device title.
         /// </value>
+        [DapperInsert]
         public string DeviceTitle { get; set; }
 
         /// <summary>
         /// Device code
         /// </summary>
+        [DapperInsert]
         public string DeviceCode { get; set; }
 
         /// <summary>
         /// Device group id
         /// </summary>
+        [DapperInsert]
         public Guid DeviceGroupId { get; set; }
 
         /// <summary>

--- a/src/DeviceManager.Api/Data/Model/DeviceGroup.cs
+++ b/src/DeviceManager.Api/Data/Model/DeviceGroup.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using DeviceManager.Api.Attributes.Dapper;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -15,6 +16,8 @@ namespace DeviceManager.Api.Data.Model
         /// Primary key
         /// No need to decorate with <see cref="KeyAttribute"/> for the Id property as long as conventions are followed. <see href="https://docs.microsoft.com/en-us/ef/core/modeling/keys#conventions"/>
         /// </summary>
+        [Key]
+        [DapperInsert]
         public Guid DeviceGroupId { get; set; }
 
         /// <summary>
@@ -26,11 +29,13 @@ namespace DeviceManager.Api.Data.Model
         /// <summary>
         /// Manufactured company
         /// </summary>
+        [DapperInsert]
         public string Company { get; set; }
 
         /// <summary>
         /// Operating system of the device
         /// </summary>
+        [DapperInsert]
         public string OperatingSystem { get; set; }
     }
 }

--- a/src/DeviceManager.Api/DeviceManager.Api.csproj
+++ b/src/DeviceManager.Api/DeviceManager.Api.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="7.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="4.0.1" />
+    <PackageReference Include="Dapper" Version="1.60.6" />
     <PackageReference Include="FluentValidation" Version="7.6.103" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="2.7.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />

--- a/src/DeviceManager.Api/Helpers/Dapper/QueryBuilderHelper.cs
+++ b/src/DeviceManager.Api/Helpers/Dapper/QueryBuilderHelper.cs
@@ -1,0 +1,78 @@
+﻿using DeviceManager.Api.Attributes.Dapper;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace DeviceManager.Api.Helpers.Dapper
+{
+    /// <summary>
+    /// This is a helper class to build dapper queries
+    /// </summary>
+    public static class QueryBuilderHelper
+    {
+        /// <summary>
+        /// Builds generic dapper find query
+        /// </summary>
+        /// <typeparam name="T">Type of the model</typeparam>
+        /// <returns></returns>
+        public static string GetFindQuery<T>()
+        {
+            var keyProperty = GetPropertiesWithAttribute<T>(typeof(KeyAttribute)).FirstOrDefault();
+            var tableName = GetTableName<T>();
+            if (keyProperty == null)
+                throw new KeyNotFoundException($"Key property not found for table {tableName}");
+            return $"SELECT * FROM {tableName} WHERE {keyProperty} = @{keyProperty}";
+        }
+
+        /// <summary>
+        /// Builds select query for the table.
+        /// </summary>
+        /// <typeparam name="T">Model type</typeparam>
+        /// <returns>Select query</returns>
+        public static string GetSelectQuery<T>() => $"SELECT * FROM {GetTableName<T>()}";
+
+        /// <summary>
+        /// Builds a insert query for the model
+        /// </summary>
+        /// <typeparam name="T">Model type</typeparam>
+        /// <returns>Insert query</returns>
+        public static string GetInsertQuery<T>()
+        {
+            var insertProperties = GetPropertiesWithAttribute<T>(typeof(DapperInsertAttribute));
+            var insertQueryBuilder = new StringBuilder($"INSERT INTO {GetTableName<T>()}(");
+            var insertPropertiesBuilder = new StringBuilder();
+            bool appendComma = false;
+            foreach (var property in insertProperties)
+            {
+                insertQueryBuilder.Append($"{(appendComma ? "," : string.Empty)} {property.Name}");
+                insertPropertiesBuilder.Append($"{(appendComma ? "," : string.Empty)} @{property.Name}");
+                appendComma = true;
+            }
+            insertQueryBuilder.Append($") VALUES({insertPropertiesBuilder.ToString()}); SELECT SCOPE_IDENTITY()");
+
+            return insertQueryBuilder.ToString();
+        }
+
+
+        /// <summary>
+        /// Gets the table based on model name. Assumes table name is model name followed by 's'
+        /// </summary>
+        /// <typeparam name="T">Model type</typeparam>
+        /// <returns>Table name</returns>
+        public static string GetTableName<T>() => $"{typeof(T).Name}s";
+
+        /// <summary>
+        /// Gets all properties on which <paramref name="attributeType"/> is defined. For eg. <see cref="DapperInsertAttribute"/>.
+        /// </summary>
+        /// <typeparam name="T">Model type</typeparam>
+        /// <param name="attributeType">Attribute type</param>
+        /// <returns>Property list</returns>
+        public static IEnumerable<PropertyInfo> GetPropertiesWithAttribute<T>(Type attributeType)
+        {
+            return typeof(T).GetProperties().Where(property => Attribute.IsDefined(property, attributeType)).OrderBy(x => x.Name);
+        }
+    }
+}

--- a/src/DeviceManager.Api/Services/IDeviceService.cs
+++ b/src/DeviceManager.Api/Services/IDeviceService.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using DeviceManager.Api.Model;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using DeviceManager.Api.Model;
 
 namespace DeviceManager.Api.Services
 {
@@ -10,6 +10,8 @@ namespace DeviceManager.Api.Services
     /// </summary>
     public interface IDeviceService
     {
+        #region Entity Framework Core
+
         /// <summary>
         /// Gets the list of devices.
         /// </summary>
@@ -49,5 +51,34 @@ namespace DeviceManager.Api.Services
         /// <param name="deviceId">The device identifier.</param>
         /// <param name="deviceViewModel">The device view model.</param>
         void UpdateDevice(Guid deviceId, DeviceViewModel deviceViewModel);
+
+        #endregion
+
+        #region Dapper
+
+        /// <summary>
+        /// Gets all devices in the database using dapper.
+        /// </summary>
+        /// <param name="page">The page.</param>
+        /// <param name="pageSize">Size of the page.</param>
+        /// <returns>Task to await</returns>
+        Task<IList<DeviceViewModel>> GetDevicesUsingDapper(int page, int pageSize);
+
+        /// <summary>
+        /// Gets the device by identifier using dapper.
+        /// </summary>
+        /// <param name="deviceId">The device identifier.</param>
+        /// <returns>Task to await</returns>
+        Task<DeviceViewModel> GetDeviceByIdUsingDapperAsync(Guid deviceId);
+
+        /// <summary>
+        /// Creates new device in the database using dapper.
+        /// </summary>
+        /// <param name="deviceViewModel">New device data</param>
+        /// <returns>Task to await device creation</returns>
+        Task CreateDeviceUsingDapperAsync(DeviceViewModel deviceViewModel);
+
+        #endregion
+
     }
 }

--- a/test/DeviceManager.Api.UnitTests/Api/DeviceApiWithDapperTests.cs
+++ b/test/DeviceManager.Api.UnitTests/Api/DeviceApiWithDapperTests.cs
@@ -1,0 +1,71 @@
+﻿using DeviceManager.Api.Constants;
+using DeviceManager.Api.Model;
+using DeviceManager.Api.UnitTests.Builders;
+using FluentAssertions;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DeviceManager.Api.UnitTests.Api
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    [Trait("Category", "Integration")]
+    public class DeviceApiWithDapperTests
+    {
+        [Fact]
+        public async Task GetDevices_WithValidParameters_ReturnsOkResult()
+        {
+            // Arrange and Act
+            var devicesApiBuilder = await new DevicesApiBuilder()
+                .WithClientCredentials();
+
+            devicesApiBuilder = await devicesApiBuilder.QueryWithDapper(page: 1, pageCount: 5, version: "1.0")
+                //.WithTenantId("b0ed668d-7ef2-4a23-a333-94ad278f45d7")
+                .WithTenantId(DefaultConstants.DefaultTenantGuid)
+                .Get();
+
+            // Assert
+            devicesApiBuilder.HttpResponseMessage.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+#if UseAuthentication
+
+        [Fact]
+        public async Task GetDevices_WithoutAuthentication_ReturnsUnauthorized()
+        {
+            // Arrange and Act
+            var devicesApiBuilder = await new DevicesApiBuilder().QueryWithDapper(page: 1, pageCount: 5, version: "1.0")
+                //.WithTenantId("b0ed668d-7ef2-4a23-a333-94ad278f45d7")
+                .WithTenantId(DefaultConstants.DefaultTenantGuid)
+                .Get();
+
+            // Assert
+            devicesApiBuilder.HttpResponseMessage.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+#endif
+        [Fact(
+            Skip = "The tests will add a new item to real DB, thus should be run manually"
+            )]
+        public async Task PostDevice_WithDeviceModel_ReturnsOkResult()
+        {
+            // Arrange and Act
+            var devicesApiBuilder = await new DevicesApiBuilder()
+                .WithClientCredentials();
+
+            devicesApiBuilder = await devicesApiBuilder.DefaultDapperQuery(version: "1.0")
+                .WithDeviceViewModelData(new DeviceViewModel()
+                {
+                    DeviceCode = "DAPPER_DFGRRO12",
+                    Title = "RO Controller"
+                })
+                .WithTenantId(DefaultConstants.DefaultTenantGuid)
+                .Post();
+
+            // Assert
+            devicesApiBuilder.HttpResponseMessage.StatusCode
+                .Should().Be(HttpStatusCode.OK);
+        }
+    }
+}

--- a/test/DeviceManager.Api.UnitTests/Builders/DevicesApiBuilder.cs
+++ b/test/DeviceManager.Api.UnitTests/Builders/DevicesApiBuilder.cs
@@ -42,6 +42,13 @@ namespace DeviceManager.Api.UnitTests.Builders
             return this;
         }
 
+        public DevicesApiBuilder DefaultDapperQuery(string version)
+        {
+            query = $"api/v{version}/devices/dapper";
+
+            return this;
+        }
+
         /// <summary>
         /// Queries with parameters.
         /// </summary>
@@ -52,6 +59,13 @@ namespace DeviceManager.Api.UnitTests.Builders
         public DevicesApiBuilder QueryWith(int page, int pageCount, string version)
         {
             query = $"api/v{version}/devices?page={page}&pageSize={pageCount}";
+
+            return this;
+        }
+
+        public DevicesApiBuilder QueryWithDapper(int page, int pageCount, string version)
+        {
+            query = $"api/v{version}/devices/dapper?page={page}&pageSize={pageCount}";
 
             return this;
         }
@@ -151,6 +165,18 @@ namespace DeviceManager.Api.UnitTests.Builders
         /// </summary>
         /// <returns></returns>
         public async Task<DevicesApiBuilder> Post()
+        {
+            // Build Post data context from json string
+            var stringContent = new StringContent(
+                deviceViewModelData,
+                Encoding.UTF8,
+                "application/json");
+
+            HttpResponseMessage = await testContextFactory.Client.PostAsync(query, stringContent);
+            return this;
+        }
+
+        public async Task<DevicesApiBuilder> PostUsingDapper()
         {
             // Build Post data context from json string
             var stringContent = new StringContent(

--- a/test/DeviceManager.Api.UnitTests/Data/Management/DapperUnitOfWorkTests.cs
+++ b/test/DeviceManager.Api.UnitTests/Data/Management/DapperUnitOfWorkTests.cs
@@ -1,0 +1,33 @@
+﻿using DeviceManager.Api.Data.Management.Dapper;
+using Moq;
+using System.Data;
+using Xunit;
+
+namespace DeviceManager.Api.UnitTests.Data.Management
+{
+    public class DapperUnitOfWorkTests
+    {
+        [Fact]
+        public void Commit_WillCallSaveChangesOnce()
+        {
+            // Arrange
+            var mockConnection = new Mock<IDbConnection>();
+            var mockTransaction = new Mock<IDbTransaction>();
+            var mockConnectionFactory = new Mock<IConnectionFactory>();
+            
+            mockConnection.Setup(mc => mc.BeginTransaction()).Returns(mockTransaction.Object);
+
+            mockConnectionFactory.Setup(cf => cf.Connection).Returns(mockConnection.Object);
+
+            var dapperUnitOfWork = new DapperUnitOfWork(mockConnectionFactory.Object);
+
+            // Act
+            dapperUnitOfWork.BeginTransaction();
+
+            dapperUnitOfWork.Commit();
+
+            //// Assert
+            mockTransaction.Verify(x => x.Commit(), Times.Once);
+        }
+    }
+}

--- a/test/DeviceManager.Api.UnitTests/Services/DeviceServiceTests.cs
+++ b/test/DeviceManager.Api.UnitTests/Services/DeviceServiceTests.cs
@@ -15,8 +15,6 @@ namespace DeviceManager.Api.UnitTests.Services
     {
         private readonly IDeviceService service;
 
-        private readonly IDeviceService serviceUsingDapper;
-
         public DeviceServiceTests()
         {
             // Build Device 
@@ -34,13 +32,6 @@ namespace DeviceManager.Api.UnitTests.Services
                 .WithValidationMock()
                 .WithUnitOfWorkSetup()
                 .Build();
-
-            // Build device service with dapper UOW
-            serviceUsingDapper = new DeviceServiceBuilder()
-                .WithDapperRepositoryMock(devicesList, device)
-                .WithValidationMock()
-                .WithDapperUnitOfWorkSetup()
-                .Build();
         }
 
         public void Dispose()
@@ -49,8 +40,6 @@ namespace DeviceManager.Api.UnitTests.Services
             // this.mockRepository.VerifyAll();
         }
         
-        #region Entity Framework Core
-
         [Fact]
         public void CreateDevice_WithValidParameters_SholdNotTrowAnyExceptions()
         {
@@ -131,53 +120,5 @@ namespace DeviceManager.Api.UnitTests.Services
             // Assert
             action.Should().NotThrow();
         }
-
-        #endregion
-
-        #region Dapper
-
-        [Fact]
-        public void CreateDevice_WithDapper_WithValidParameters_SholdNotThrowAnyExceptions()
-        {
-            // Arrange
-            var deviceViewModel = new DeviceViewModel
-            {
-                Title = String.Empty,
-                DeviceCode = String.Empty,
-            };
-
-            // Act
-            Func<Task> comparison = async () => { await serviceUsingDapper.CreateDeviceUsingDapperAsync(deviceViewModel); };
-
-            // Assert
-            comparison.Should().NotThrow();
-        }
-
-        [Fact]
-        public void GetDevices_WithDapper_WithValidParameters_SholdNotThrowAnyExceptions()
-        {
-            // Arrange
-
-            // Act
-            Func<Task> comparison = async () => { await serviceUsingDapper.GetDevicesUsingDapper(1, 1); };
-
-            // Assert
-            comparison.Should().NotThrow();
-        }
-
-        [Fact]
-        public async void GetDevices_WithDapper_WithValidParameters_ShouldHaveOneElement()
-        {
-            // Arrange
-
-            // Act
-            IList<DeviceViewModel> devices = await serviceUsingDapper.GetDevicesUsingDapper(1, 1);
-
-            // Assert
-            devices.Should().NotBeNull();
-            devices.Should().HaveCount(1);
-        }
-
-        #endregion
     }
 }

--- a/test/DeviceManager.Api.UnitTests/Services/DeviceServiceWithDapperTests.cs
+++ b/test/DeviceManager.Api.UnitTests/Services/DeviceServiceWithDapperTests.cs
@@ -1,0 +1,88 @@
+﻿using DeviceManager.Api.Data.Model;
+using DeviceManager.Api.Model;
+using DeviceManager.Api.Services;
+using DeviceManager.Api.UnitTests.Builders;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DeviceManager.Api.UnitTests.Services
+{
+    public class DeviceServiceWithDapperTests : IDisposable
+    {
+        private readonly IDeviceService service;
+
+        /// <summary>
+        /// Test device services using dapper
+        /// </summary>
+        public DeviceServiceWithDapperTests()
+        {
+            // Build Device 
+            Device device = new DeviceBuilder()
+                .WithId("27be25a2-1b69-4476-a90f-f80498f5e2ec")
+                .WithTitle("Raspberry3")
+                .Build();
+
+            // Build Device list
+            List<Device> devicesList = new List<Device> { device };
+
+
+            // Build device service with dapper UOW
+            service = new DeviceServiceBuilder()
+                .WithDapperRepositoryMock(devicesList, device)
+                .WithValidationMock()
+                .WithDapperUnitOfWorkSetup()
+                .Build();
+        }
+
+        public void Dispose()
+        {
+            // TODO: Correct verification 
+            // this.mockRepository.VerifyAll();
+        }
+        
+        [Fact]
+        public void CreateDevice_WithValidParameters_SholdNotThrowAnyExceptions()
+        {
+            // Arrange
+            var deviceViewModel = new DeviceViewModel
+            {
+                Title = String.Empty,
+                DeviceCode = String.Empty,
+            };
+
+            // Act
+            Func<Task> comparison = async () => { await service.CreateDeviceUsingDapperAsync(deviceViewModel); };
+
+            // Assert
+            comparison.Should().NotThrow();
+        }
+
+        [Fact]
+        public void GetDevices_WithValidParameters_SholdNotThrowAnyExceptions()
+        {
+            // Arrange
+
+            // Act
+            Func<Task> comparison = async () => { await service.GetDevicesUsingDapper(1, 1); };
+
+            // Assert
+            comparison.Should().NotThrow();
+        }
+
+        [Fact]
+        public async void GetDevices_WithValidParameters_ShouldHaveOneElement()
+        {
+            // Arrange
+
+            // Act
+            IList<DeviceViewModel> devices = await service.GetDevicesUsingDapper(1, 1);
+
+            // Assert
+            devices.Should().NotBeNull();
+            devices.Should().HaveCount(1);
+        }
+    }
+}


### PR DESCRIPTION
Hi @Boriszn,

I have added dapper support with its own DapperUnitOfWork. Also, I have added a generic repository capable of building `insert` and `select` queries based on the attributes defined for the model properties. I have created separate files for dapper tests.
In the future, I will add support for `update` and `delete`. 

Thanks,
Rudresh